### PR TITLE
ci: migrate CodeQL runner to self-hosted ARC (develop)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Migrates the CodeQL `analyze` job from `ubuntu-latest` to the self-hosted ARC fleet via `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (smallest _4 per CodeQL/SARIF policy). k8s-build.yml already uses the ARC var and is left untouched. No arm/macos/windows runners touched.